### PR TITLE
refactor(data): conform all data services to interface

### DIFF
--- a/src/app/data/services/data-service.interface.ts
+++ b/src/app/data/services/data-service.interface.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs/Observable';
 
 export interface DataService<T> {
-  getAll(): Observable<Array<T>>;
+  getAll(params?: any): Observable<Array<T>>;
   get?(id: string): Observable<T>;
   save?(T): Observable<T>;
   delete?(T): Observable<T>;

--- a/src/app/data/services/project/project.service.spec.ts
+++ b/src/app/data/services/project/project.service.spec.ts
@@ -52,6 +52,33 @@ describe('ProjectService', () => {
     });
   });
 
+  describe('get', () => {
+    it('gets the specified project', () => {
+      let connection: MockConnection;
+      mockBackend.connections.subscribe(c => connection = c);
+
+      let result;
+      service.get('42731138').subscribe((res) => { result = res; });
+      expect(connection.request.url).toEqual(`${environment.dataService}/projects/42731138`);
+      expect(connection.request.method).toEqual(RequestMethod.Get);
+      connection.mockRespond(new Response(new ResponseOptions({
+        status: 200,
+        body: {
+          _id: '42731138',
+          name: 'Deep Geeky Thoughts About Total Control'
+        }
+      })));
+      expect(result).toEqual({
+        _id: '42731138',
+        name: 'Deep Geeky Thoughts About Total Control'
+      });
+    });
+
+    it('throws an exception if called without an id', function() {
+      expect(function() { service.get(); }).toThrowError('ProjectService.get() called without id');
+    });
+  });
+
   describe('save', () => {
     it('posts new projects', () => {
       let connection: MockConnection;

--- a/src/app/data/services/project/project.service.ts
+++ b/src/app/data/services/project/project.service.ts
@@ -21,6 +21,15 @@ export class ProjectService implements DataService<Project> {
       .map(res => res.json());
   }
 
+  get(id: string): Observable<Project> {
+    if (!id) {
+      throw new Error('ProjectService.get() called without id');
+    }
+
+    return this.http.get(`${this.url}/${id}`)
+      .map(res => res.json());
+  }
+
   save(project: Project): Observable<Project> {
     return this.http.post(this.url + (project._id ? `/${project._id}` : ''), project)
       .map(res => res.json());

--- a/src/app/data/services/stage/stage.service.ts
+++ b/src/app/data/services/stage/stage.service.ts
@@ -2,13 +2,14 @@ import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 
+import { DataService } from '../data-service.interface';
 import { Stage } from '../../models/stage';
 import { environment } from '../../../../environments/environment';
 
 import 'rxjs/add/operator/map';
 
 @Injectable()
-export class StageService {
+export class StageService implements DataService<Stage> {
   private stages: Observable<Array<Stage>>;
 
   constructor(private http: Http) { }
@@ -16,7 +17,7 @@ export class StageService {
   getAll(): Observable<Array<Stage>> {
     if (!this.stages) {
       this.stages = this.http.get(`${environment.dataService}/stages`)
-      .map(res => res.json());
+        .map(res => res.json());
     }
 
     return this.stages;

--- a/src/app/data/services/taskTimer/taskTimer.service.spec.ts
+++ b/src/app/data/services/taskTimer/taskTimer.service.spec.ts
@@ -2,6 +2,7 @@
 
 import { Http, Response, ResponseOptions, RequestMethod, BaseRequestOptions } from '@angular/http';
 import { MockBackend, MockConnection } from '@angular/http/testing';
+import { Observable } from 'rxjs/Observable';
 
 import { TaskTimerService } from './taskTimer.service';
 import { environment } from '../../../../environments/environment';
@@ -23,12 +24,22 @@ describe('TaskTimerService', () => {
     expect(service).toBeTruthy();
   });
 
-  describe('get all for timesheet', () => {
+  describe('get all', () => {
+    it('throws an error if called with no parameter', () => {
+      expect(function() { service.getAll(); })
+        .toThrowError('TaskTimerService.getAll() must be called with a parameter object specifying the timesheetId');
+    });
+
+    it('throws an error if called with a parameter specifying somethting other than a timesheetId', () => {
+      expect(function() { service.getAll({ projectId: '42' }); })
+        .toThrowError('TaskTimerService.getAll() must be called with a parameter object specifying the timesheetId');
+    });
+
     it('sends a request to get all task timers for the timesheet', () => {
       let connection: MockConnection;
       mockBackend.connections.subscribe(c => connection = c);
 
-      service.getAllForTimesheet('1138');
+      service.getAll({ timesheetId: '1138' });
       expect(connection.request.url).toEqual(`${environment.dataService}/timesheets/1138/taskTimers`);
       expect(connection.request.method).toEqual(RequestMethod.Get);
     });
@@ -38,7 +49,7 @@ describe('TaskTimerService', () => {
       mockBackend.connections.subscribe(c => connection = c);
 
       let result;
-      service.getAllForTimesheet('1138').subscribe(res => result = res);
+      service.getAll({ timesheetId: '1138' }).subscribe(res => result = res);
       connection.mockRespond(new Response(new ResponseOptions({
         status: 200,
         body: [{
@@ -79,7 +90,7 @@ describe('TaskTimerService', () => {
       });
 
       let result;
-      service.getAllForTimesheet('1138').subscribe(res => result = res);
+      service.getAll({ timesheetId: '1138' }).subscribe(res => result = res);
       connection.mockRespond(new Response(new ResponseOptions({
         status: 200,
         body: [{
@@ -98,7 +109,7 @@ describe('TaskTimerService', () => {
       })));
 
       for (let x = 0; x < 100; x++) {
-        service.getAllForTimesheet('1138').subscribe(res => result = res);
+        service.getAll({ timesheetId: '1138' }).subscribe(res => result = res);
       }
 
       expect(connectionCount).toEqual(1);
@@ -116,7 +127,7 @@ describe('TaskTimerService', () => {
         workDate: '2016-12-01'
       }]);
 
-      service.getAllForTimesheet('7342');
+      service.getAll({ timesheetId: '7342' });
       expect(connectionCount).toEqual(2);
       expect(connection.request.url).toEqual(`${environment.dataService}/timesheets/7342/taskTimers`);
       expect(connection.request.method).toEqual(RequestMethod.Get);
@@ -124,11 +135,23 @@ describe('TaskTimerService', () => {
   });
 
   describe('start', () => {
+    it('throws an error if task timers have not been fetched yet', () => {
+      let res;
+      service.start({
+        _id: '42',
+        timesheetRid: '1138'
+      }).catch(err => {
+        res = err;
+        return Observable.empty();
+      }).subscribe();
+      expect(res).toEqual(new Error('No Timers Fetched Yet'));
+    });
+
     it('sends a request to start the given timer', () => {
       let connection: MockConnection;
       mockBackend.connections.subscribe(c => connection = c);
 
-      service.getAllForTimesheet('1138').subscribe();
+      service.getAll({ timesheetId: '1138' }).subscribe();
       connection.mockRespond(new Response(new ResponseOptions({
         status: 200,
         body: [{
@@ -150,7 +173,7 @@ describe('TaskTimerService', () => {
       let connection: MockConnection;
       mockBackend.connections.subscribe(c => connection = c);
 
-      service.getAllForTimesheet('1138').subscribe();
+      service.getAll({ timesheetId: '1138' }).subscribe();
       connection.mockRespond(new Response(new ResponseOptions({
         status: 200,
         body: [{
@@ -190,7 +213,7 @@ describe('TaskTimerService', () => {
         connections.push(c);
       });
 
-      service.getAllForTimesheet('1138').subscribe();
+      service.getAll({ timesheetId: '1138' }).subscribe();
       connection.mockRespond(new Response(new ResponseOptions({
         status: 200,
         body: [{

--- a/src/app/data/services/taskTimer/taskTimer.service.ts
+++ b/src/app/data/services/taskTimer/taskTimer.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 
+import { DataService } from '../data-service.interface';
 import { TaskTimer } from '../../models/taskTimer';
 import { environment } from '../../../../environments/environment';
 
@@ -12,13 +13,19 @@ import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/map';
 
 @Injectable()
-export class TaskTimerService {
+export class TaskTimerService implements DataService<TaskTimer> {
   private taskTimers: Observable<Array<TaskTimer>>;
   private timesheetId: string;
 
   constructor(private http: Http) { }
 
-  getAllForTimesheet(timesheetId: string): Observable<Array<TaskTimer>> {
+  getAll(params: any): Observable<Array<TaskTimer>> {
+    const timesheetId = params && params.timesheetId;
+
+    if (!timesheetId) {
+      throw new Error('TaskTimerService.getAll() must be called with a parameter object specifying the timesheetId');
+    }
+
     if (this.timesheetId !== timesheetId) {
       this.timesheetId = timesheetId;
       this.taskTimers = this.http.get(`${environment.dataService}/timesheets/${timesheetId}/taskTimers`)

--- a/src/app/data/services/timesheet/timesheet.service.spec.ts
+++ b/src/app/data/services/timesheet/timesheet.service.spec.ts
@@ -172,7 +172,7 @@ describe('TimesheetService', () => {
       let connection: MockConnection;
       mockBackend.connections.subscribe(c => connection = c);
 
-      service.post({
+      service.save({
         _id: '42',
         endDate: '2016-12-24',
         userRid: 'me'
@@ -190,7 +190,7 @@ describe('TimesheetService', () => {
       let connection: MockConnection;
       mockBackend.connections.subscribe(c => connection = c);
 
-      service.post({
+      service.save({
         endDate: '2016-12-24',
         userRid: 'me'
       });
@@ -207,7 +207,7 @@ describe('TimesheetService', () => {
       mockBackend.connections.subscribe(c => connection = c);
 
       let result;
-      service.post({
+      service.save({
         endDate: '2016-12-24',
         userRid: 'me'
       }).subscribe(res => result = res);

--- a/src/app/data/services/timesheet/timesheet.service.ts
+++ b/src/app/data/services/timesheet/timesheet.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 
+import { DataService } from '../data-service.interface';
 import { DateService } from '../../../shared/date/date.service';
 import { Timesheet } from '../../models/timesheet';
 import { environment } from '../../../../environments/environment';
@@ -11,23 +12,26 @@ import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
 
 @Injectable()
-export class TimesheetService {
+export class TimesheetService implements DataService<Timesheet> {
+  private url: string;
 
-  constructor(private http: Http, private dates: DateService) { }
+  constructor(private http: Http, private dates: DateService) {
+    this.url = `${environment.dataService}/timesheets`;
+  }
 
   getAll(): Observable<Array<Timesheet>> {
-    return this.http.get(`${environment.dataService}/timesheets`)
+    return this.http.get(this.url)
       .map(res => res.json());
   }
 
   get(id: string): Observable<Timesheet> {
-    return this.http.get(`${environment.dataService}/timesheets/${id}`)
+    return this.http.get(this.url + `/${id}`)
       .map(res => res.json());
   }
 
   getCurrent(): Observable<Timesheet> {
     const endDate = this.dates.weekEndDate(new Date());
-    return this.http.get(`${environment.dataService}/timesheets?endDate=${endDate}`)
+    return this.http.get(this.url + `?endDate=${endDate}`)
       .map(res => res.json())
       .catch((e) => {
         if (e.status === 404) {
@@ -40,11 +44,8 @@ export class TimesheetService {
       });
   }
 
-  post(timesheet: Timesheet): Observable<Timesheet> {
-    let url = `${environment.dataService}/timesheets`;
-    if (timesheet._id) {
-      url += `/${timesheet._id}`;
-    }
+  save(timesheet: Timesheet): Observable<Timesheet> {
+    const url = this.url + (timesheet._id ? `/${timesheet._id}` : '');
 
     return this.http.post(url, timesheet)
       .map(res => res.json());


### PR DESCRIPTION
The interfact being used allows for getAll(), get(id), and save(id). This keeps the use of data consistent from service to service.