### PR TITLE
feat(timesheet): add a service to manipulate timer data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "./node_modules/typescript/lib"
+}

--- a/src/app/data/models/timesheet.ts
+++ b/src/app/data/models/timesheet.ts
@@ -1,4 +1,4 @@
-export interface Timesheet {
+export class Timesheet {
   _id: string;
   endDate: string;
   userRid: string;

--- a/src/app/shared/services/timesheet-report/daily-time-log.ts
+++ b/src/app/shared/services/timesheet-report/daily-time-log.ts
@@ -1,0 +1,9 @@
+import { TaskTimer } from '../../../data/models/task-timer';
+
+export class DailyTimeLog {
+  taskTimers: Array<TaskTimer>;
+
+  constructor(public date: Date) {
+    this.taskTimers = [];
+  }
+}

--- a/src/app/shared/services/timesheet-report/timesheet-report.service.spec.ts
+++ b/src/app/shared/services/timesheet-report/timesheet-report.service.spec.ts
@@ -1,0 +1,59 @@
+/* tslint:disable:no-unused-variable */
+
+import { TaskTimer } from '../../../data/models/task-timer';
+import { Timesheet } from '../../../data/models/timesheet';
+import { TimesheetReportService } from './timesheet-report.service';
+
+describe('TimesheetReportService', () => {
+  let service: TimesheetReportService;
+  beforeEach(() => {
+    service = new TimesheetReportService();
+  });
+
+  it('should exist', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('dailyTasks', () => {
+    it('contains an entry for each day in the timesheet', () => {
+      const ts = new Timesheet();
+      ts.endDate = '2017-01-28';
+      const d = service.dailyTasks(ts, []);
+      expect(d.length).toEqual(7);
+      for (let i = 0; i < 7; i++) {
+        expect(d[i].date).toEqual(new Date(2017, 0, 22 + i));
+      }
+    });
+
+    it('divides the task timers by day', () => {
+      const ts = new Timesheet();
+      ts.endDate = '2017-01-28';
+
+      const d = service.dailyTasks(ts, [newTaskTimer('2017-01-24'), newTaskTimer('2017-01-26'), newTaskTimer('2017-01-27'),
+      newTaskTimer('2017-01-23'), newTaskTimer('2017-01-26'), newTaskTimer('2017-01-25'), newTaskTimer('2017-01-25'),
+      newTaskTimer('2017-01-25'), newTaskTimer('2017-01-23'), newTaskTimer('2017-01-27'), newTaskTimer('2017-01-24'),
+      newTaskTimer('2017-01-25'), newTaskTimer('2017-01-26'), newTaskTimer('2017-01-23'), newTaskTimer('2017-01-24'),
+      newTaskTimer('2017-01-24'), newTaskTimer('2017-01-24')]);
+
+      expect(d[0].taskTimers.length).toEqual(0, 'Sunday');
+      expect(d[1].taskTimers.length).toEqual(3, 'Monday');
+      expect(d[2].taskTimers.length).toEqual(5, 'Tuesday');
+      expect(d[3].taskTimers.length).toEqual(4, 'Wednesday');
+      expect(d[4].taskTimers.length).toEqual(3, 'Thursday');
+      expect(d[5].taskTimers.length).toEqual(2, 'Friday');
+      expect(d[6].taskTimers.length).toEqual(0, 'Saturday');
+    });
+  });
+
+  function newTaskTimer(dt: string): TaskTimer {
+    const tt = {
+      _id: '427331459',
+      timesheetRid: '11389578',
+      workDate: dt,
+      stage: null,
+      project: null
+    };
+
+    return tt;
+  }
+});

--- a/src/app/shared/services/timesheet-report/timesheet-report.service.ts
+++ b/src/app/shared/services/timesheet-report/timesheet-report.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+
+import * as _ from 'lodash';
+import * as moment from 'moment';
+
+import { DailyTimeLog } from './daily-time-log';
+import { TaskTimer } from '../../../data/models/task-timer';
+import { Timesheet } from '../../../data/models/timesheet';
+
+@Injectable()
+export class TimesheetReportService {
+
+  constructor() { }
+
+  dailyTasks(timesheet: Timesheet, tasks: Array<TaskTimer>): Array<DailyTimeLog> {
+    const week = this.generateWeek(timesheet.endDate);
+    week.forEach((day) => { day.taskTimers = this.tasksForDay(tasks, day.date); });
+
+    return week;
+  }
+
+  private generateWeek(endDate: any): Array<DailyTimeLog> {
+    const m = moment(endDate);
+    const week: Array<DailyTimeLog> = [];
+
+    for (let i = 6; i >= 0; i--) {
+      week.push(new DailyTimeLog(moment(m).subtract(i, 'days').toDate()));
+    }
+
+    return week;
+  }
+
+  private tasksForDay(tasks: Array<TaskTimer>, dt: Date): Array<TaskTimer> {
+    return _.filter(tasks, (task) => {
+      return moment(task.workDate).valueOf() === dt.getTime();
+    });
+  }
+}


### PR DESCRIPTION
This service provides routines that take raw timesheet and task timer information and provide data structures that allow us to display the data in a meaningful manner.